### PR TITLE
Remove the parenthesised paragraph intended for the organisers.

### DIFF
--- a/speaker_data/Adam_Harvey.php
+++ b/speaker_data/Adam_Harvey.php
@@ -13,7 +13,7 @@ GitHub: https://github.com/LawnGnome',
       'title' => 'PHP in 2013: generators, and password hashing, and finally (oh my!)',
       'text' => 'The release date may have slipped a bit, but 2012 saw the introduction of PHP 5.4. This added new features, but perhaps more importantly, removed a number of legacy “features” that had long since proved to be more problematic than useful.
 2013 brings PHP 5.5 to the table, and where 5.4 looked backward to make PHP a more consistent language, 2013 sees PHP looking forward. In keeping with the trend over the last couple of years towards more frequent, smaller releases, this release is evolutionary rather than revolutionary, but a number of oft-requested language features such as generators and finally have been added, and a new password hashing API has been added which promises to finally sweep away the need for simplified wrapper libraries around crypt() and the hash functions.
-In this talk, I’ll discuss how 5.4 has matured, what 5.5 will bring, and how the formal release process adopted between 5.3 and 5.4 affects developers and sysadmins maintaining PHP installs and the best ways to keep an up-to-date, secure PHP install.'),
+In this talk, I’ll discuss how 5.4 has matured, what 5.5 will bring, and how the formal release process adopted between 5.3 and 5.4 affects developers and sysadmins maintaining PHP installs and the best ways to keep an up-to-date, secure PHP install.',
     ),
   ),
 );


### PR DESCRIPTION
There's a paragraph in my talk abstract that wasn't really meant for the public. (Nothing wrong with it, but it clutters the page up for no reason.) This commit removes it.

Also, technically I'm Australian according to my passport, but since you don't have a flag for that I haven't included that in the PR. :)
