### PR TITLE
Specify UTF-8 output by default.

### DIFF
--- a/header.php
+++ b/header.php
@@ -17,10 +17,13 @@ if (!isset($_COOKIE['mobileNoPrompt'])){
         exit;
     }
 }
+
+header('Content-Type: text/html; charset=UTF-8');
 ?>
 <!DOCTYPE html>
 <html>
    <head>
+      <meta charset="UTF-8">
       <title>True North PHP Conference - November 7-9, 2013 - Toronto, Canada</title>
       <?php foreach ($css as $name) { ?>
       <link rel="stylesheet" href="<?php echo $name ?>">


### PR DESCRIPTION
At the moment, no charset is specified for the Web site, which means that apostrophes and quotes in many people's bios and abstracts look bad (including mine). The speaker data files all appear to be UTF-8, so setting the charset explicitly in header.php should fix this.
